### PR TITLE
Autoscan

### DIFF
--- a/apolline-flutter/lib/bluetoothDevicesPage.dart
+++ b/apolline-flutter/lib/bluetoothDevicesPage.dart
@@ -42,6 +42,7 @@ class _BluetoothDevicesPageState extends State<BluetoothDevicesPage> {
     this.ucS.addListener(() {
       LocalKeyValuePersistance.saveObject("userconf", ucS.userConf.toJson());
     });
+    initializeDevice();
   }
 
   ///


### PR DESCRIPTION
When the application is started, a Bluetooth scan is automatically launched (no need to press the button to trigger it manually anymore).