### PR TITLE
Excluding flutter_blue from minification

### DIFF
--- a/apolline-flutter/android/app/build.gradle
+++ b/apolline-flutter/android/app/build.gradle
@@ -51,6 +51,7 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/apolline-flutter/android/app/proguard-rules.pro
+++ b/apolline-flutter/android/app/proguard-rules.pro
@@ -1,0 +1,2 @@
+# The protos need to have all their names and fields preserved.
+-keep class com.pauldemarco.flutter_blue.Protos* { *; }


### PR DESCRIPTION
`flutter_blue` does not work after compilation, so we exclude the library from minification.

See https://github.com/pauldemarco/flutter_blue/issues/772#issuecomment-827404250 for more details.