### PR TITLE
fix: Reporting sensor name to backend

### DIFF
--- a/apolline-flutter/lib/models/sensormodel.dart
+++ b/apolline-flutter/lib/models/sensormodel.dart
@@ -133,7 +133,7 @@ class SensorModel {
       : this.bdd(
             id: json['id'],
             values: json['value'].split('|'),
-            device: SensorDevice.fromNameAndUId(json['name'], json['uuid']),
+            device: SensorDevice.fromNameAndUId(json['deviceName'], json['uuid']),
             position: Position(geohash: json['geohash'], provider: json['provider'], transport: json['transport']),
             date: json['date']);
 }


### PR DESCRIPTION
When sending data to backend, wrong variable name was used, which led to all sensors being named "Apolline00" (default value).
With this fix, sensor name is correctly reported to the backend, allowing us to display data by sensor name as such:
![Capture d’écran de 2021-08-10 09-24-24](https://user-images.githubusercontent.com/11993538/128825725-d0c1419a-1627-46fb-9ff9-5660a4384219.png)
