### PR TITLE
fix: Scan prerequisites

### DIFF
--- a/apolline-flutter/assets/translations/en-GB.json
+++ b/apolline-flutter/assets/translations/en-GB.json
@@ -1,8 +1,8 @@
 {
   "devicesView": {
     "title": "Apolline - Sensors",
-    "bluetoothPopUp": {
-      "title": "Bluetooth is disabled",
+    "permissionsPopUp": {
+      "title": "Missing permissions",
       "message": "Activate both Bluetooth and geolocation to detect devices."
     },
     "pairedDevicesLabel": "Paired devices",

--- a/apolline-flutter/assets/translations/fr-FR.json
+++ b/apolline-flutter/assets/translations/fr-FR.json
@@ -1,8 +1,8 @@
 {
   "devicesView": {
     "title": "Apolline - Capteurs",
-    "bluetoothPopUp": {
-      "title": "Bluetooth désactivé",
+    "permissionsPopUp": {
+      "title": "Permissions insuffisantes",
       "message": "Activez le Bluetooth et la géolocalisation pour permettre la détection de périphériques."
     },
     "pairedDevicesLabel": "Périphériques appairés",

--- a/apolline-flutter/lib/bluetoothDevicesPage.dart
+++ b/apolline-flutter/lib/bluetoothDevicesPage.dart
@@ -7,6 +7,8 @@ import 'package:apollineflutter/services/local_persistant_service.dart';
 import 'package:apollineflutter/services/user_configuration_service.dart';
 import 'package:apollineflutter/services/service_locator.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:grant_and_activate/grant_and_activate.dart';
+import 'package:grant_and_activate/utils/service.dart';
 
 
 
@@ -39,7 +41,7 @@ class _BluetoothDevicesPageState extends State<BluetoothDevicesPage> {
   ///
   ///Permet de tester si le bluetooth est activé ou pas
   Future<void> initializeDevice() async {
-    var isOn = await widget.flutterBlue.isOn;
+    bool isOn = await checkPermissionsAndActivateServices([Service.Bluetooth, Service.Location]);
     if (isOn) {
       _performDetection();
     } else {

--- a/apolline-flutter/lib/bluetoothDevicesPage.dart
+++ b/apolline-flutter/lib/bluetoothDevicesPage.dart
@@ -45,13 +45,13 @@ class _BluetoothDevicesPageState extends State<BluetoothDevicesPage> {
     if (result.allOk) {
       _performDetection();
     } else {
-      showDialogBluetooth();
+      showPermissionsDialog();
     }
   }
 
   ///
-  ///Afficher un message pour activer le bluetooth
-  void showDialogBluetooth() {
+  ///Afficher un message pour activer le bluetooth et la geoloc
+  void showPermissionsDialog() {
     Widget okbtn = TextButton(
       child: Text("OK"),
       onPressed: () {
@@ -60,8 +60,8 @@ class _BluetoothDevicesPageState extends State<BluetoothDevicesPage> {
     );
 
     AlertDialog alert = AlertDialog(
-      title: Text("devicesView.bluetoothPopUp.title").tr(),
-      content: Text("devicesView.bluetoothPopUp.message").tr(),
+      title: Text("devicesView.permissionsPopUp.title").tr(),
+      content: Text("devicesView.permissionsPopUp.message").tr(),
       actions: [okbtn],
     );
 

--- a/apolline-flutter/lib/bluetoothDevicesPage.dart
+++ b/apolline-flutter/lib/bluetoothDevicesPage.dart
@@ -8,7 +8,7 @@ import 'package:apollineflutter/services/user_configuration_service.dart';
 import 'package:apollineflutter/services/service_locator.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:grant_and_activate/grant_and_activate.dart';
-import 'package:grant_and_activate/utils/service.dart';
+import 'package:grant_and_activate/utils/classes.dart';
 
 
 
@@ -41,8 +41,8 @@ class _BluetoothDevicesPageState extends State<BluetoothDevicesPage> {
   ///
   ///Permet de tester si le bluetooth est activé ou pas
   Future<void> initializeDevice() async {
-    bool isOn = await checkPermissionsAndActivateServices([Service.Bluetooth, Service.Location]);
-    if (isOn) {
+    Result result = await checkPermissionsAndActivateServices([Feature.Bluetooth, Feature.Location]);
+    if (result.allOk) {
       _performDetection();
     } else {
       showDialogBluetooth();

--- a/apolline-flutter/pubspec.lock
+++ b/apolline-flutter/pubspec.lock
@@ -241,9 +241,9 @@ packages:
   grant_and_activate:
     dependency: "direct main"
     description:
-      path: "../../grant_and_activate"
-      relative: true
-    source: path
+      name: grant_and_activate
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.0.1"
   http:
     dependency: "direct main"

--- a/apolline-flutter/pubspec.lock
+++ b/apolline-flutter/pubspec.lock
@@ -22,6 +22,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.5.0"
+  bluetooth_enable:
+    dependency: transitive
+    description:
+      name: bluetooth_enable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -231,6 +238,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  grant_and_activate:
+    dependency: "direct main"
+    description:
+      path: "../../grant_and_activate"
+      relative: true
+    source: path
+    version: "0.0.1"
   http:
     dependency: "direct main"
     description:
@@ -273,6 +287,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.3"
+  location:
+    dependency: transitive
+    description:
+      name: location
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.3.0"
+  location_platform_interface:
+    dependency: transitive
+    description:
+      name: location_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.0"
+  location_web:
+    dependency: transitive
+    description:
+      name: location_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.1"
   matcher:
     dependency: transitive
     description:
@@ -366,6 +401,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.11.1"
+  permission_handler:
+    dependency: transitive
+    description:
+      name: permission_handler
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "8.1.4+2"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.6.1"
   petitparser:
     dependency: transitive
     description:

--- a/apolline-flutter/pubspec.yaml
+++ b/apolline-flutter/pubspec.yaml
@@ -46,6 +46,8 @@ dependencies:
   shared_preferences: ^2.0.6
   flutter_background: ^1.0.2+1
   easy_localization: ^3.0.0
+  grant_and_activate:
+    path: ../../grant_and_activate
 
 
 

--- a/apolline-flutter/pubspec.yaml
+++ b/apolline-flutter/pubspec.yaml
@@ -46,8 +46,7 @@ dependencies:
   shared_preferences: ^2.0.6
   flutter_background: ^1.0.2+1
   easy_localization: ^3.0.0
-  grant_and_activate:
-    path: ../../grant_and_activate
+  grant_and_activate: ^0.0.1
 
 
 


### PR DESCRIPTION
Before scanning for sensors, checks if permissions have been granted for Bluetooth and geolocation services, and if both services are running.