### PR TITLE
fix: Sensor reconnection

### DIFF
--- a/apolline-flutter/pubspec.lock
+++ b/apolline-flutter/pubspec.lock
@@ -142,10 +142,12 @@ packages:
   flutter_blue:
     dependency: "direct main"
     description:
-      name: flutter_blue
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.8.0"
+      path: "."
+      ref: "0.11.0"
+      resolved-ref: f6bf99be778bdbeac9a41fbb0eb36597325109ac
+      url: "https://github.com/boskokg/flutter_blue/"
+    source: git
+    version: "0.11.0"
   flutter_launcher_icons:
     dependency: "direct main"
     description:
@@ -461,7 +463,7 @@ packages:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.26.0"
+    version: "0.27.2"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/apolline-flutter/pubspec.yaml
+++ b/apolline-flutter/pubspec.yaml
@@ -11,7 +11,7 @@ description: Apolline sensors app
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.5.3+13
+version: 1.5.4+14
 publish_to: none
 
 environment:

--- a/apolline-flutter/pubspec.yaml
+++ b/apolline-flutter/pubspec.yaml
@@ -21,7 +21,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_blue: ^0.8.0
+  flutter_blue:
+    git:
+      url: https://github.com/boskokg/flutter_blue/
+      ref: 0.11.0
   fluttertoast: ^8.0.8
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
* using a fork of `flutter_blue` package since it is not maintained anymore;
* sensor reconnection is done after BLE signal lost (due to distance);
* disconnection message is displayed when sensor runs out of battery.

---

- [x] Increase version number