### PR TITLE
fix: Typo in graph data translation key

### DIFF
--- a/apolline-flutter/assets/translations/en-GB.json
+++ b/apolline-flutter/assets/translations/en-GB.json
@@ -25,7 +25,7 @@
   "temperature": "TEMPERATURE",
   "statsView": {
     "pauseGathering": "Pause data gathering",
-    "startGathering": "Resume data gathering"
+    "resumeGathering": "Resume data gathering"
   },
   "mapView": {
     "timeFilters": {

--- a/apolline-flutter/assets/translations/fr-FR.json
+++ b/apolline-flutter/assets/translations/fr-FR.json
@@ -25,7 +25,7 @@
   "temperature": "TEMPÉRATURE",
   "statsView": {
     "pauseGathering": "Mettre en pause l'affichage des données",
-    "startGathering": "Reprendre l'affichage des données"
+    "resumeGathering": "Reprendre l'affichage des données"
   },
   "mapView": {
     "timeFilters": {


### PR DESCRIPTION
Wrong key was used, resulting in it being displayed to users instead of related translation.