### PR TITLE
feat: Sensor events

### DIFF
--- a/apolline-flutter/assets/translations/en-GB.json
+++ b/apolline-flutter/assets/translations/en-GB.json
@@ -102,5 +102,13 @@
     "home": "Measures",
     "chart": "Chart",
     "map": "Map"
+  },
+  "events": {
+    "noEventsText": "No events registered for this device.",
+    "types": {
+      "disconnection": "Disconnected from sensor",
+      "connection": "Connected to sensor",
+      "liveData": "Air quality data received (live)"
+    }
   }
 }

--- a/apolline-flutter/assets/translations/fr-FR.json
+++ b/apolline-flutter/assets/translations/fr-FR.json
@@ -102,5 +102,13 @@
     "home": "Mesures",
     "chart": "Graphique",
     "map": "Carte"
+  },
+  "events": {
+    "noEventsText": "Aucun événement enregistré pour ce périphérique.",
+    "types": {
+      "disconnection": "Déconnecté du capteur",
+      "connection": "Connecté au capteur",
+      "liveData": "Données de qualité de l'air reçues (live)"
+    }
   }
 }

--- a/apolline-flutter/lib/models/user_configuration.dart
+++ b/apolline-flutter/lib/models/user_configuration.dart
@@ -158,4 +158,11 @@ class UserConfiguration {
     if (this._sensorEvents[deviceName] == null) this._sensorEvents[deviceName] = [];
     this._sensorEvents[deviceName].add( SensorEvent(event) );
   }
+  void clearSensorEvents (String deviceName) {
+    DateTime now = DateTime.now();
+    print("Removing sensor events older than one week.");
+    this._sensorEvents[deviceName] =
+        this._sensorEvents[deviceName]
+            .where((element) => now.difference(element.time) < Duration(days: 7)).toList();
+  }
 }

--- a/apolline-flutter/lib/models/user_configuration.dart
+++ b/apolline-flutter/lib/models/user_configuration.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:apollineflutter/utils/pm_filter.dart';
+import 'package:apollineflutter/utils/sensor_events/SensorEvent.dart';
 import 'package:apollineflutter/utils/time_filter.dart';
 
 
@@ -18,6 +19,8 @@ class UserConfiguration {
   List<bool> _shouldSendThresholdNotifications;
   ///exposure notifications time interval
   Duration exposureNotificationsTimeInterval;
+  ///sensor events
+  List<SensorEvent> _sensorEvents;
 
   ///Json keys
   static const String TIME_FILTER_KEY = "timeFilterValue";
@@ -25,6 +28,7 @@ class UserConfiguration {
   static const String THRESHOLDS_KEY = "thresholdsValue";
   static const String ALERTS_KEY = "thresholdsAlertsValue";
   static const String NOTIFICATIONS_KEY = "notificationsValue";
+  static const String SENSOR_EVENTS_KEY = "sensorEventsKey";
 
   ///
   ///Constructor
@@ -32,7 +36,8 @@ class UserConfiguration {
     pmFilter: PMFilter.PM_2_5,
     Map<PMFilter, int> thresholds,
     List<bool> alerts,
-    Duration notificationsInterval: const Duration(minutes: 5)
+    Duration notificationsInterval: const Duration(minutes: 5),
+    List<SensorEvent> sensorEvents
   }) {
     this._timeFilter = timeFilter;
     this._pmFilter = pmFilter;
@@ -43,6 +48,9 @@ class UserConfiguration {
     this._thresholdsValues = thresholds == null || thresholds.keys.length == 0
         ? PMFilterUtils.getThresholds()
         : thresholds;
+    this._sensorEvents = sensorEvents == null || _sensorEvents.length == 0
+      ? []
+      : sensorEvents;
   }
 
   ///
@@ -51,6 +59,7 @@ class UserConfiguration {
     this._timeFilter = TimeFilter.values[jsonMap[UserConfiguration.TIME_FILTER_KEY]];
     this._pmFilter = PMFilter.values[jsonMap[UserConfiguration.PM_FILTER_KEY]];
     this._shouldSendThresholdNotifications = jsonMap[UserConfiguration.ALERTS_KEY].cast<bool>();
+    this._sensorEvents = jsonMap[UserConfiguration.SENSOR_EVENTS_KEY].cast<SensorEvent>();
 
     Map<String, dynamic> values = json.decode(jsonMap[UserConfiguration.THRESHOLDS_KEY]);
     Map<PMFilter, List<int>> thresholds = Map();
@@ -127,5 +136,9 @@ class UserConfiguration {
   }
   set showDangerNotifications (bool value) {
     this._shouldSendThresholdNotifications[1] = value;
+  }
+
+  List<SensorEvent> getSensorEvents () {
+    return this._sensorEvents;
   }
 }

--- a/apolline-flutter/lib/models/user_configuration.dart
+++ b/apolline-flutter/lib/models/user_configuration.dart
@@ -60,7 +60,13 @@ class UserConfiguration {
     this._timeFilter = TimeFilter.values[jsonMap[UserConfiguration.TIME_FILTER_KEY]];
     this._pmFilter = PMFilter.values[jsonMap[UserConfiguration.PM_FILTER_KEY]];
     this._shouldSendThresholdNotifications = jsonMap[UserConfiguration.ALERTS_KEY].cast<bool>();
-    this._sensorEvents = jsonMap[UserConfiguration.SENSOR_EVENTS_KEY].cast<SensorEvent>();
+
+    List<dynamic> eventValues = jsonMap[UserConfiguration.SENSOR_EVENTS_KEY];
+    List<SensorEvent> events = [];
+    eventValues.forEach((element) {
+      events.add(SensorEvent.fromJson(element));
+    });
+    this._sensorEvents = events;
 
     Map<String, dynamic> values = json.decode(jsonMap[UserConfiguration.THRESHOLDS_KEY]);
     Map<PMFilter, List<int>> thresholds = Map();
@@ -85,7 +91,8 @@ class UserConfiguration {
       UserConfiguration.PM_FILTER_KEY: this._pmFilter.index,
       UserConfiguration.THRESHOLDS_KEY: json.encode(jsonValues),
       UserConfiguration.ALERTS_KEY: this._shouldSendThresholdNotifications,
-      UserConfiguration.NOTIFICATIONS_KEY: this.exposureNotificationsTimeInterval.inMilliseconds
+      UserConfiguration.NOTIFICATIONS_KEY: this.exposureNotificationsTimeInterval.inMilliseconds,
+      UserConfiguration.SENSOR_EVENTS_KEY: this._sensorEvents
     };
   }
 

--- a/apolline-flutter/lib/models/user_configuration.dart
+++ b/apolline-flutter/lib/models/user_configuration.dart
@@ -149,7 +149,7 @@ class UserConfiguration {
   List<SensorEvent> get sensorEvents {
     return this._sensorEvents;
   }
-  void addSensorEvent (SensorEventType event) {
+  void addSensorEvent (String deviceName, SensorEventType event) {
     this._sensorEvents.add( SensorEvent(event) );
   }
 }

--- a/apolline-flutter/lib/models/user_configuration.dart
+++ b/apolline-flutter/lib/models/user_configuration.dart
@@ -21,7 +21,7 @@ class UserConfiguration {
   ///exposure notifications time interval
   Duration exposureNotificationsTimeInterval;
   ///sensor events
-  List<SensorEvent> _sensorEvents;
+  Map<String, List<SensorEvent>> _sensorEvents;
 
   ///Json keys
   static const String TIME_FILTER_KEY = "timeFilterValue";
@@ -49,9 +49,9 @@ class UserConfiguration {
     this._thresholdsValues = thresholds == null || thresholds.keys.length == 0
         ? PMFilterUtils.getThresholds()
         : thresholds;
-    this._sensorEvents = sensorEvents == null || _sensorEvents.length == 0
-      ? []
-      : sensorEvents;
+    this._sensorEvents = sensorEvents == null || _sensorEvents.keys.length == 0
+        ? {}
+        : sensorEvents;
   }
 
   ///
@@ -61,10 +61,15 @@ class UserConfiguration {
     this._pmFilter = PMFilter.values[jsonMap[UserConfiguration.PM_FILTER_KEY]];
     this._shouldSendThresholdNotifications = jsonMap[UserConfiguration.ALERTS_KEY].cast<bool>();
 
-    List<dynamic> eventValues = jsonMap[UserConfiguration.SENSOR_EVENTS_KEY];
-    List<SensorEvent> events = [];
-    eventValues.forEach((element) {
-      events.add(SensorEvent.fromJson(element));
+    Map<String, dynamic> eventValues = jsonMap[UserConfiguration.SENSOR_EVENTS_KEY];
+    Map<String, List<SensorEvent>> events = {};
+    eventValues.forEach((key, value) {
+      print(key);
+      List<SensorEvent> localEvents = [];
+      (value as List<dynamic>).forEach((element) {
+        localEvents.add(SensorEvent.fromJson(element));
+      });
+      events.putIfAbsent(key, () => localEvents);
     });
     this._sensorEvents = events;
 
@@ -146,10 +151,11 @@ class UserConfiguration {
     this._shouldSendThresholdNotifications[1] = value;
   }
 
-  List<SensorEvent> get sensorEvents {
-    return this._sensorEvents;
+  List<SensorEvent> getSensorEvents(String deviceName) {
+    return this._sensorEvents[deviceName];
   }
   void addSensorEvent (String deviceName, SensorEventType event) {
-    this._sensorEvents.add( SensorEvent(event) );
+    if (this._sensorEvents[deviceName] == null) this._sensorEvents[deviceName] = [];
+    this._sensorEvents[deviceName].add( SensorEvent(event) );
   }
 }

--- a/apolline-flutter/lib/models/user_configuration.dart
+++ b/apolline-flutter/lib/models/user_configuration.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:apollineflutter/utils/pm_filter.dart';
 import 'package:apollineflutter/utils/sensor_events/SensorEvent.dart';
+import 'package:apollineflutter/utils/sensor_events/SensorEventType.dart';
 import 'package:apollineflutter/utils/time_filter.dart';
 
 
@@ -138,7 +139,10 @@ class UserConfiguration {
     this._shouldSendThresholdNotifications[1] = value;
   }
 
-  List<SensorEvent> getSensorEvents () {
+  List<SensorEvent> get sensorEvents {
     return this._sensorEvents;
+  }
+  void addSensorEvent (SensorEventType event) {
+    this._sensorEvents.add( SensorEvent(event) );
   }
 }

--- a/apolline-flutter/lib/sensor_view.dart
+++ b/apolline-flutter/lib/sensor_view.dart
@@ -6,6 +6,7 @@ import 'package:apollineflutter/twins/SensorTwinEvent.dart';
 import 'package:apollineflutter/utils/device_connection_status.dart';
 import 'package:apollineflutter/utils/pm_filter.dart';
 import 'package:apollineflutter/utils/sensor_events/SensorEventType.dart';
+import 'package:apollineflutter/utils/sensor_events/events_dialog.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_background/flutter_background.dart';
@@ -272,14 +273,16 @@ class _SensorViewState extends State<SensorView> {
     return _sensor != null
         ? Container(
           margin: EdgeInsets.only(right: 15),
-          child: Icon(
-              Icons.circle_sharp,
-              color: !this.isConnected
-                  ? Colors.red
-                  : this._receivedData
+          child: IconButton(
+              onPressed: () => showSensorEventsDialog(context, widget.device.name),
+              icon: Icon(
+                Icons.circle_sharp,
+                color: !this.isConnected
+                    ? Colors.red
+                    : this._receivedData
                     ? Colors.green.shade800
                     : Colors.green.shade900,
-          )
+              ))
         )
         : Container();
   }

--- a/apolline-flutter/lib/sensor_view.dart
+++ b/apolline-flutter/lib/sensor_view.dart
@@ -61,12 +61,17 @@ class _SensorViewState extends State<SensorView> {
   Map<bool, int> _notificationTimestamps = Map();
   final GlobalKey<ScaffoldMessengerState> _scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
   bool _receivedData = false;
+  Timer timer;
 
 
   @override
   void initState() {
     super.initState();
     initializeDevice();
+    timer = Timer.periodic(Duration(minutes: 5), (timer) {
+      widget.ucS.userConf.clearSensorEvents(widget.device.name);
+      widget.ucS.update();
+    });
   }
 
 
@@ -253,6 +258,7 @@ class _SensorViewState extends State<SensorView> {
     widget.device.disconnect();
     this._sensor?.shutdown();
     disableBackgroundExecution();
+    this.timer.cancel();
     super.dispose();
   }
 

--- a/apolline-flutter/lib/sensor_view.dart
+++ b/apolline-flutter/lib/sensor_view.dart
@@ -142,7 +142,7 @@ class _SensorViewState extends State<SensorView> {
   }
 
   void _onLiveDataReceived (DataPointModel model) {
-    widget.ucS.userConf.addSensorEvent(SensorEventType.LiveData);
+    widget.ucS.userConf.addSensorEvent(widget.device.name, SensorEventType.LiveData);
     widget.ucS.update();
 
     setState(() {
@@ -182,7 +182,7 @@ class _SensorViewState extends State<SensorView> {
   }
 
   void _onSensorConnected () {
-    widget.ucS.userConf.addSensorEvent(SensorEventType.Connection);
+    widget.ucS.userConf.addSensorEvent(widget.device.name, SensorEventType.Connection);
     widget.ucS.update();
 
     if (connectType == ConnexionType.Disconnect && !isConnected) {
@@ -195,7 +195,7 @@ class _SensorViewState extends State<SensorView> {
   }
 
   void _onSensorDisconnected () {
-    widget.ucS.userConf.addSensorEvent(SensorEventType.Disconnection);
+    widget.ucS.userConf.addSensorEvent(widget.device.name, SensorEventType.Disconnection);
     widget.ucS.update();
 
     print("----------------disconnected----------------");

--- a/apolline-flutter/lib/sensor_view.dart
+++ b/apolline-flutter/lib/sensor_view.dart
@@ -58,6 +58,7 @@ class _SensorViewState extends State<SensorView> {
   SensorTwin _sensor;
   Map<bool, int> _notificationTimestamps = Map();
   final GlobalKey<ScaffoldMessengerState> _scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
+  bool _receivedData = false;
 
 
   @override
@@ -141,6 +142,13 @@ class _SensorViewState extends State<SensorView> {
   void _onLiveDataReceived (DataPointModel model) {
     setState(() {
       lastReceivedData = model;
+      this._receivedData = true;
+    });
+
+    Future.delayed(Duration(milliseconds: 150), () {
+      setState(() {
+        this._receivedData = false;
+      });
     });
 
     if (!widget.ucS.userConf.showDangerNotifications && !widget.ucS.userConf.showWarningNotifications) return;
@@ -180,7 +188,9 @@ class _SensorViewState extends State<SensorView> {
 
   void _onSensorDisconnected () {
     print("----------------disconnected----------------");
-    isConnected = false;
+    setState(() {
+      isConnected = false;
+    });
     connectType = ConnexionType.Disconnect; //deconnexion
     showSnackBar("connectionMessages.disconnected".tr(), duration: Duration(days: 1));
   }
@@ -248,6 +258,22 @@ class _SensorViewState extends State<SensorView> {
     return false;
   }
 
+  Widget _getActionIndicator() {
+    return _sensor != null
+        ? Container(
+          margin: EdgeInsets.only(right: 15),
+          child: Icon(
+              Icons.circle_sharp,
+              color: !this.isConnected
+                  ? Colors.red
+                  : this._receivedData
+                    ? Colors.green.shade800
+                    : Colors.green.shade900,
+          )
+        )
+        : Container();
+  }
+
   /* UI update only */
   @override
   Widget build(BuildContext context) {
@@ -280,6 +306,9 @@ class _SensorViewState extends State<SensorView> {
           ),
           appBar: AppBar(
             title: Text(_sensor != null ? _sensor.name : "connectionMessages.connecting".tr()),
+            actions: [
+              this._getActionIndicator()
+            ],
           ),
           body: Stack(
             children: [

--- a/apolline-flutter/lib/sensor_view.dart
+++ b/apolline-flutter/lib/sensor_view.dart
@@ -5,6 +5,7 @@ import 'package:apollineflutter/twins/SensorTwin.dart';
 import 'package:apollineflutter/twins/SensorTwinEvent.dart';
 import 'package:apollineflutter/utils/device_connection_status.dart';
 import 'package:apollineflutter/utils/pm_filter.dart';
+import 'package:apollineflutter/utils/sensor_events/SensorEventType.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_background/flutter_background.dart';
@@ -140,6 +141,9 @@ class _SensorViewState extends State<SensorView> {
   }
 
   void _onLiveDataReceived (DataPointModel model) {
+    widget.ucS.userConf.addSensorEvent(SensorEventType.LiveData);
+    widget.ucS.update();
+
     setState(() {
       lastReceivedData = model;
       this._receivedData = true;
@@ -177,6 +181,9 @@ class _SensorViewState extends State<SensorView> {
   }
 
   void _onSensorConnected () {
+    widget.ucS.userConf.addSensorEvent(SensorEventType.Connection);
+    widget.ucS.update();
+
     if (connectType == ConnexionType.Disconnect && !isConnected) {
       print("-------------------connectedExécute---------");
       handleDeviceConnect(widget.device);
@@ -187,6 +194,9 @@ class _SensorViewState extends State<SensorView> {
   }
 
   void _onSensorDisconnected () {
+    widget.ucS.userConf.addSensorEvent(SensorEventType.Disconnection);
+    widget.ucS.update();
+
     print("----------------disconnected----------------");
     setState(() {
       isConnected = false;

--- a/apolline-flutter/lib/utils/sensor_events/SensorEvent.dart
+++ b/apolline-flutter/lib/utils/sensor_events/SensorEvent.dart
@@ -10,4 +10,13 @@ class SensorEvent {
         ? DateTime.now()
         : DateTime.parse(time);
   }
+
+  SensorEvent.fromJson(Map<String, dynamic> json)
+      : type = SensorEventType.values[json['type']],
+        time = DateTime.parse(json['time']);
+
+  Map<String, dynamic> toJson() => {
+    'type': this.type.index,
+    'time': this.time.toIso8601String(),
+  };
 }

--- a/apolline-flutter/lib/utils/sensor_events/SensorEvent.dart
+++ b/apolline-flutter/lib/utils/sensor_events/SensorEvent.dart
@@ -1,0 +1,11 @@
+import 'package:apollineflutter/utils/sensor_events/SensorEventType.dart';
+
+class SensorEvent {
+  SensorEventType type;
+  DateTime time;
+
+  SensorEvent(this.type) {
+    this.type = type;
+    this.time = DateTime.now();
+  }
+}

--- a/apolline-flutter/lib/utils/sensor_events/SensorEvent.dart
+++ b/apolline-flutter/lib/utils/sensor_events/SensorEvent.dart
@@ -4,8 +4,10 @@ class SensorEvent {
   SensorEventType type;
   DateTime time;
 
-  SensorEvent(this.type) {
+  SensorEvent(this.type, {String time = ""}) {
     this.type = type;
-    this.time = DateTime.now();
+    this.time = time.length == 0
+        ? DateTime.now()
+        : DateTime.parse(time);
   }
 }

--- a/apolline-flutter/lib/utils/sensor_events/SensorEventType.dart
+++ b/apolline-flutter/lib/utils/sensor_events/SensorEventType.dart
@@ -1,3 +1,17 @@
 enum SensorEventType {
   Connection, Disconnection, LiveData
 }
+
+extension SensorEventTypeUtils on SensorEventType {
+  static final Map<SensorEventType, String> _labels = {
+    SensorEventType.Connection: "Connected to sensor",
+    SensorEventType.Disconnection: "Disconnection from sensor",
+    SensorEventType.LiveData: "Air quality data received (live)"
+  };
+
+  String get label {
+    if (SensorEventTypeUtils._labels[this] == null)
+      throw RangeError("This SensorEventType has no associated label.");
+    return SensorEventTypeUtils._labels[this];
+  }
+}

--- a/apolline-flutter/lib/utils/sensor_events/SensorEventType.dart
+++ b/apolline-flutter/lib/utils/sensor_events/SensorEventType.dart
@@ -1,0 +1,3 @@
+enum SensorEventType {
+  Connection, Disconnection, LiveData
+}

--- a/apolline-flutter/lib/utils/sensor_events/SensorEventType.dart
+++ b/apolline-flutter/lib/utils/sensor_events/SensorEventType.dart
@@ -1,17 +1,19 @@
+import 'package:easy_localization/easy_localization.dart';
+
 enum SensorEventType {
   Connection, Disconnection, LiveData
 }
 
 extension SensorEventTypeUtils on SensorEventType {
   static final Map<SensorEventType, String> _labels = {
-    SensorEventType.Connection: "Connected to sensor",
-    SensorEventType.Disconnection: "Disconnection from sensor",
-    SensorEventType.LiveData: "Air quality data received (live)"
+    SensorEventType.Connection: "events.types.connection",
+    SensorEventType.Disconnection: "events.types.disconnection",
+    SensorEventType.LiveData: "events.types.liveData"
   };
 
   String get label {
     if (SensorEventTypeUtils._labels[this] == null)
       throw RangeError("This SensorEventType has no associated label.");
-    return SensorEventTypeUtils._labels[this];
+    return SensorEventTypeUtils._labels[this].tr();
   }
 }

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -16,7 +16,7 @@ void showSensorEventsDialog(BuildContext context, String deviceName) {
               height: 300,
               width: 300,
               child: ListView(
-                children: _getEventCards(),
+                children: _getEventCards(deviceName),
               )
           ),
         );
@@ -24,9 +24,9 @@ void showSensorEventsDialog(BuildContext context, String deviceName) {
   );
 }
 
-List<Widget> _getEventCards () {
+List<Widget> _getEventCards (String deviceName) {
   List<Widget> widgets = [];
-  ucS.userConf.sensorEvents.forEach((event) {
+  ucS.userConf.getSensorEvents(deviceName).forEach((event) {
     widgets.add(
       ListTile(
         title: Text(event.type.toString()),

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -15,14 +15,14 @@ void showSensorEventsDialog(BuildContext context, String deviceName) {
         return AlertDialog(
           title: Text(deviceName),
           contentPadding: EdgeInsets.only(left: 0, bottom: 0, right: 0, top: 20),
-          content: Container(
+          content: _hasEventsForSensor(deviceName) ? Container(
               height: 300,
               width: 300,
-              child: _hasEventsForSensor(deviceName) ? ListView(
+              child: ListView(
                 children: _getEventCards(deviceName),
-              ) : ListTile(
-                title: Text("No events registered for this device."),
               )
+          ) : ListTile(
+            title: Text("No events registered for this device."),
           ),
         );
       }

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:apollineflutter/services/service_locator.dart';
 import 'package:apollineflutter/services/user_configuration_service.dart';
+import 'package:apollineflutter/utils/sensor_events/SensorEventType.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
@@ -35,7 +36,7 @@ List<Widget> _getEventCards (String deviceName) {
   ucS.userConf.getSensorEvents(deviceName).forEach((event) {
     widgets.add(
       ListTile(
-        title: Text(event.type.toString()),
+        title: Text(event.type.label),
         subtitle: Text(event.time.toString()),
       )
     );

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -22,7 +22,7 @@ void showSensorEventsDialog(BuildContext context, String deviceName) {
                 children: _getEventCards(deviceName),
               )
           ) : ListTile(
-            title: Text("No events registered for this device."),
+            title: Text("events.noEventsText").tr(),
           ),
         );
       }

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -15,13 +15,19 @@ void showSensorEventsDialog(BuildContext context, String deviceName) {
           content: Container(
               height: 300,
               width: 300,
-              child: ListView(
+              child: _hasEventsForSensor(deviceName) ? ListView(
                 children: _getEventCards(deviceName),
+              ) : ListTile(
+                title: Text("No events registered for this device."),
               )
           ),
         );
       }
   );
+}
+
+bool _hasEventsForSensor(String deviceName) {
+  return ucS.userConf.getSensorEvents(deviceName) != null;
 }
 
 List<Widget> _getEventCards (String deviceName) {

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -1,10 +1,12 @@
 import 'package:apollineflutter/services/service_locator.dart';
 import 'package:apollineflutter/services/user_configuration_service.dart';
 import 'package:apollineflutter/utils/sensor_events/SensorEventType.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 final UserConfigurationService ucS = locator<UserConfigurationService>();
+final DateFormat formatter = DateFormat('dd-MM-yyyy H:m:s');
 
 void showSensorEventsDialog(BuildContext context, String deviceName) {
   showDialog(
@@ -37,7 +39,7 @@ List<Widget> _getEventCards (String deviceName) {
     widgets.add(
       ListTile(
         title: Text(event.type.label),
-        subtitle: Text(event.time.toString()),
+        subtitle: Text(formatter.format(event.time).toString()),
       )
     );
   });

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -1,0 +1,38 @@
+import 'package:apollineflutter/services/service_locator.dart';
+import 'package:apollineflutter/services/user_configuration_service.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+final UserConfigurationService ucS = locator<UserConfigurationService>();
+
+void showSensorEventsDialog(BuildContext context, String deviceName) {
+  showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text(deviceName),
+          contentPadding: EdgeInsets.only(left: 0, bottom: 0, right: 0, top: 20),
+          content: Container(
+              height: 300,
+              width: 300,
+              child: ListView(
+                children: _getEventCards(),
+              )
+          ),
+        );
+      }
+  );
+}
+
+List<Widget> _getEventCards () {
+  List<Widget> widgets = [];
+  ucS.userConf.sensorEvents.forEach((event) {
+    widgets.add(
+      ListTile(
+        title: Text(event.type.toString()),
+        subtitle: Text(event.time.toString()),
+      )
+    );
+  });
+  return widgets.reversed.toList();
+}

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -40,6 +40,11 @@ List<Widget> _getEventCards (String deviceName) {
       ListTile(
         title: Text(event.type.label),
         subtitle: Text(formatter.format(event.time).toString()),
+        tileColor: event.type == SensorEventType.Connection
+            ? Colors.green.shade100
+            : event.type == SensorEventType.Disconnection
+              ? Colors.red.shade100
+              : Colors.white
       )
     );
   });

--- a/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
+++ b/apolline-flutter/lib/utils/sensor_events/events_dialog.dart
@@ -6,7 +6,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 final UserConfigurationService ucS = locator<UserConfigurationService>();
-final DateFormat formatter = DateFormat('dd-MM-yyyy H:m:s');
+final DateFormat formatter = DateFormat('dd-MM-yyyy HH:mm:ss');
 
 void showSensorEventsDialog(BuildContext context, String deviceName) {
   showDialog(

--- a/apolline-flutter/lib/widgets/device_card.dart
+++ b/apolline-flutter/lib/widgets/device_card.dart
@@ -1,3 +1,4 @@
+import 'package:apollineflutter/utils/sensor_events/events_dialog.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_blue/flutter_blue.dart';
@@ -21,6 +22,9 @@ class _DeviceCardState extends State<DeviceCard> {
         subtitle: Text(widget.device.id.toString()),
         onTap: () {
           widget.connectionCallback(widget.device);
+        },
+        onLongPress: () {
+          showSensorEventsDialog(context, widget.device.name);
         },
         enabled: widget.enabled,
         trailing: widget.enabled ? null : Icon(Icons.bluetooth_disabled_outlined),

--- a/apolline-flutter/pubspec.yaml
+++ b/apolline-flutter/pubspec.yaml
@@ -11,7 +11,7 @@ description: Apolline sensors app
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.5.4+14
+version: 1.6.0+15
 publish_to: none
 
 environment:

--- a/releaseNotes/whatsnew-en-GB
+++ b/releaseNotes/whatsnew-en-GB
@@ -1,6 +1,3 @@
-Notifications time interval picker has been fixed.
-Warning and danger notifications can be displayed at the same time.
-
-Sensor reconnection is done automatically after signal loss.
-
-The application is now compatible with more devices, ranging from Android Marshmallow (6) to Android 12.
+An activity indicator shows connection state on sensor view.
+Sensor connection events are stored on the smartphone and visible by the user; those older than one
+week are automatically removed.

--- a/releaseNotes/whatsnew-fr-FR
+++ b/releaseNotes/whatsnew-fr-FR
@@ -1,7 +1,3 @@
-Le sélecteur de délai entre deux notifications consécutives fonctionne désormais correctement.
-Les notifications d'alerte et de danger peuvent apparaître en même temps.
-
-La reconnection au capteur se fait automatiquement après une perte de connexion.
-
-L'application est maintenant compatible à partir d'Android Marshmallow (6) et fonctionne correctement
-sur Android 12.
+Un indicateur d'activité montre l'état de la connexion avec le capteur.
+Les événements de connexion aux capteurs sont stockés sur le téléphone et visibles par l'utilisateur ;
+ceux datant de plus d'une semaine sont automatiquement supprimés.


### PR DESCRIPTION
Sensor connection events are stored on the smartphone and visible by the user.
An activity indicator shows connection state on sensor view.

---

- [x] Store data under device name keys
- [x] Print a message if device has no attached events
- [x] Add event type description
- [x] Format dialog events time string
- [x] Events older than one week are automatically removed
- [x] Update version