### PR TITLE
fix: Saving settings

### DIFF
--- a/apolline-flutter/assets/translations/en-GB.json
+++ b/apolline-flutter/assets/translations/en-GB.json
@@ -91,11 +91,13 @@
     "setTimeIntervalBody": "Set which duration must pass before a new notification is sent.",
     "warning": {
       "title": "Warning threshold",
-      "incorrect": "Must be inferior than danger value."
+      "incorrect": "Must be inferior than danger value.",
+      "toastMessage": "Warning value must be inferior to danger value."
     },
     "danger": {
       "title": "Danger threshold",
-      "incorrect": "Must be superior to warning value."
+      "incorrect": "Must be superior to warning value.",
+      "toastMessage": "Danger value must be superior to warning value."
     }
   },
   "navigation": {

--- a/apolline-flutter/assets/translations/fr-FR.json
+++ b/apolline-flutter/assets/translations/fr-FR.json
@@ -91,11 +91,13 @@
     "setTimeIntervalBody": "Choisissez combien de temps doit s'écouler entre l'envoi de deux notifications.",
     "warning": {
       "title": "Seuil d'alerte",
-      "incorrect": "Doit être inférieur au seuil de danger."
+      "incorrect": "Doit être inférieur au seuil de danger.",
+      "toastMessage": "Le seuil d'alerte doit être inférieur au seuil de danger."
     },
     "danger": {
       "title": "Seuil de danger",
-      "incorrect": "Doit être supérieur au seuil d'alerte."
+      "incorrect": "Doit être supérieur au seuil d'alerte.",
+      "toastMessage": "Le seuil de danger doit être supérieur au seuil d'alerte."
     }
   },
   "navigation": {

--- a/apolline-flutter/lib/utils/pm_card.dart
+++ b/apolline-flutter/lib/utils/pm_card.dart
@@ -74,17 +74,13 @@ class _PMCardState extends State<PMCard> {
                     setState(() {
                       isDangerValueCorrect = _isDangerValueCorrect;
                       isWarningValueCorrect = _isWarningValueCorrect;
-                    });
-                  },
-                  initialValue: warningThresholdValue.toString(),
-                  onFieldSubmitted: (value) {
-                    if (value.isEmpty) return;
-                    setState(() {
                       warningThresholdValue = int.parse(value);
                     });
+
                     widget.ucS.userConf.updatePMThreshold(widget.indicator, 0, int.parse(value));
                     widget.ucS.update();
                   },
+                  initialValue: warningThresholdValue.toString(),
                   decoration: InputDecoration(
                       border: InputBorder.none,
                       hintText: "15",
@@ -113,17 +109,13 @@ class _PMCardState extends State<PMCard> {
                     setState(() {
                       isDangerValueCorrect = _isDangerValueCorrect;
                       isWarningValueCorrect = _isWarningValueCorrect;
-                    });
-                  },
-                  initialValue: dangerThresholdValue.toString(),
-                  onFieldSubmitted: (value) {
-                    if (value.isEmpty) return;
-                    setState(() {
                       dangerThresholdValue = int.parse(value);
                     });
+
                     widget.ucS.userConf.updatePMThreshold(widget.indicator, 1, int.parse(value));
                     widget.ucS.update();
                   },
+                  initialValue: dangerThresholdValue.toString(),
                   decoration: InputDecoration(
                       border: InputBorder.none,
                       hintText: "30",

--- a/apolline-flutter/lib/utils/pm_card.dart
+++ b/apolline-flutter/lib/utils/pm_card.dart
@@ -4,6 +4,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 
 
 class PMCard extends StatefulWidget {
@@ -63,9 +64,16 @@ class _PMCardState extends State<PMCard> {
                   inputFormatters: widget.formatters,
                   onChanged: (value) {
                     if (value.isEmpty) return;
+                    bool _isDangerValueCorrect = int.parse(value) < dangerThresholdValue;
+                    bool _isWarningValueCorrect = int.parse(value) < dangerThresholdValue;
+
+                    if (!_isDangerValueCorrect || !_isWarningValueCorrect) {
+                      Fluttertoast.showToast(msg: "Warning value must be inferior to danger value.");
+                    }
+
                     setState(() {
-                      isWarningValueCorrect = int.parse(value) < dangerThresholdValue;
-                      isDangerValueCorrect = int.parse(value) < dangerThresholdValue;
+                      isDangerValueCorrect = _isDangerValueCorrect;
+                      isWarningValueCorrect = _isWarningValueCorrect;
                     });
                   },
                   initialValue: warningThresholdValue.toString(),
@@ -95,9 +103,16 @@ class _PMCardState extends State<PMCard> {
                   inputFormatters: widget.formatters,
                   onChanged: (value) {
                     if (value.isEmpty) return;
+                    bool _isDangerValueCorrect = int.parse(value) > warningThresholdValue;
+                    bool _isWarningValueCorrect = int.parse(value) > warningThresholdValue;
+
+                    if (!_isDangerValueCorrect || !_isWarningValueCorrect) {
+                      Fluttertoast.showToast(msg: "Danger value must be superior to warning value.");
+                    }
+
                     setState(() {
-                      isDangerValueCorrect = int.parse(value) > warningThresholdValue;
-                      isWarningValueCorrect = int.parse(value) > warningThresholdValue;
+                      isDangerValueCorrect = _isDangerValueCorrect;
+                      isWarningValueCorrect = _isWarningValueCorrect;
                     });
                   },
                   initialValue: dangerThresholdValue.toString(),

--- a/apolline-flutter/lib/utils/pm_card.dart
+++ b/apolline-flutter/lib/utils/pm_card.dart
@@ -68,7 +68,7 @@ class _PMCardState extends State<PMCard> {
                     bool _isWarningValueCorrect = int.parse(value) < dangerThresholdValue;
 
                     if (!_isDangerValueCorrect || !_isWarningValueCorrect) {
-                      Fluttertoast.showToast(msg: "Warning value must be inferior to danger value.");
+                      Fluttertoast.showToast(msg: "settings.warning.toastMessage".tr());
                     }
 
                     setState(() {
@@ -103,7 +103,7 @@ class _PMCardState extends State<PMCard> {
                     bool _isWarningValueCorrect = int.parse(value) > warningThresholdValue;
 
                     if (!_isDangerValueCorrect || !_isWarningValueCorrect) {
-                      Fluttertoast.showToast(msg: "Danger value must be superior to warning value.");
+                      Fluttertoast.showToast(msg: "settings.danger.toastMessage".tr());
                     }
 
                     setState(() {

--- a/apolline-flutter/pubspec.yaml
+++ b/apolline-flutter/pubspec.yaml
@@ -11,7 +11,7 @@ description: Apolline sensors app
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.6.0+15
+version: 1.6.1+16
 publish_to: none
 
 environment:

--- a/releaseNotes/whatsnew-en-GB
+++ b/releaseNotes/whatsnew-en-GB
@@ -1,3 +1,2 @@
-An activity indicator shows connection state on sensor view.
-Sensor connection events are stored on the smartphone and visible by the user; those older than one
-week are automatically removed.
+Warning/danger thresholds are automatically saved when their value is updated by the user.
+Toast messages are displayed when a faulty value is entered.

--- a/releaseNotes/whatsnew-fr-FR
+++ b/releaseNotes/whatsnew-fr-FR
@@ -1,3 +1,3 @@
-Un indicateur d'activité montre l'état de la connexion avec le capteur.
-Les événements de connexion aux capteurs sont stockés sur le téléphone et visibles par l'utilisateur ;
-ceux datant de plus d'une semaine sont automatiquement supprimés.
+Les seuils d'avertissement/danger sont sauvegardés automatiquement dès que leur valeur est changée
+par l'utilisateur.
+Des messages d'alerte sont affichés si une valeur entrée est incorrecte.


### PR DESCRIPTION
* since there's no input validation on iOS keyboard, settings are saved each time a value is updated;
* a toast message is displayed when a faulty value is entered.